### PR TITLE
Changed setting of authorities for new JwtUserDetails objects to set …

### DIFF
--- a/Servers/Zuul/src/main/resources/bootstrap.yml
+++ b/Servers/Zuul/src/main/resources/bootstrap.yml
@@ -21,6 +21,7 @@ ribbon:
 
       
 zuul: 
+  sensitiveHeaders: Cookie, Set-Cookie #Zuul will block these and only these headers from continuing to other services.
   routes: 
     register: 
       path: /api/getUsers

--- a/Servers/cep-engagement-service/src/main/java/com/cepengagementservice/security/AuthenticationConfig.java
+++ b/Servers/cep-engagement-service/src/main/java/com/cepengagementservice/security/AuthenticationConfig.java
@@ -87,9 +87,9 @@ public class AuthenticationConfig extends WebSecurityConfigurerAdapter {
             .exceptionHandling().authenticationEntryPoint(jwtUnAuthorizedResponseAuthenticationEntryPoint).and() //handles any exceptions with custom handler
             .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS).and() //ensures that expired sessions are cleaned up
             .authorizeRequests()//Allows restricting access based upon the HttpServletRequest using RequestMatcher implementations
-            .antMatchers("/v3/api-docs/**", "/configuration/**", "/swagger*/**", "/webjars/**", "/", "/console/**").permitAll(); // permits all users to access Swagger V3 URLS
-            //.antMatchers("/users/all", "/interventions").hasAnyRole("ADMIN")  // Restricts getting all users and intervention requests to ADMIN users.
-            //.anyRequest().authenticated();// If you are authorized you will be able to access any routes that aren't specified to the ADMIN role.
+            .antMatchers("/v3/api-docs/**", "/configuration/**", "/swagger*/**", "/webjars/**", "/", "/console/**").permitAll() // permits all users to access Swagger V3 URLS
+            .antMatchers("/users/all", "/interventions").hasAnyRole("ADMIN")  // Restricts getting all users and intervention requests to ADMIN users.
+            .anyRequest().authenticated();// If you are authorized you will be able to access any routes that aren't specified to the ADMIN role.
         
        httpSecurity
             .addFilterBefore(jwtAuthenticationTokenFilter, UsernamePasswordAuthenticationFilter.class);

--- a/Servers/cep-engagement-service/src/main/java/com/cepengagementservice/security/JwtUserDetails.java
+++ b/Servers/cep-engagement-service/src/main/java/com/cepengagementservice/security/JwtUserDetails.java
@@ -32,7 +32,7 @@ public class JwtUserDetails extends User implements UserDetails {
 		this.setEmail(user.getEmail());
 
 		List<SimpleGrantedAuthority> authorities = new ArrayList<SimpleGrantedAuthority>();
-		authorities.add(new SimpleGrantedAuthority(getRole()));
+		authorities.add(new SimpleGrantedAuthority("ROLE_" + getRole()));
 		this.authorities = authorities;
 	}
 
@@ -41,7 +41,7 @@ public class JwtUserDetails extends User implements UserDetails {
 		super();
 
 		List<SimpleGrantedAuthority> authorities = new ArrayList<SimpleGrantedAuthority>();
-		authorities.add(new SimpleGrantedAuthority(getRole()));
+		authorities.add(new SimpleGrantedAuthority("ROLE_" + getRole()));
 		this.authorities = authorities;
 	}
 


### PR DESCRIPTION
Changed how authorizations were created for JwtUserDetails objects to make them roles instead of authorizations, then re-activated the role-checking in the back-end. Removed the Authorization header from Zuul's sensitiveHeaders property, so Zuul will no longer remove it from HTTP requests.