### PR TITLE
JwtUserDetails no longer inserts ROLE_ before role names, Authenticat…

### DIFF
--- a/Servers/cep-engagement-service/src/main/java/com/cepengagementservice/security/AuthenticationConfig.java
+++ b/Servers/cep-engagement-service/src/main/java/com/cepengagementservice/security/AuthenticationConfig.java
@@ -88,7 +88,9 @@ public class AuthenticationConfig extends WebSecurityConfigurerAdapter {
             .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS).and() //ensures that expired sessions are cleaned up
             .authorizeRequests()//Allows restricting access based upon the HttpServletRequest using RequestMatcher implementations
             .antMatchers("/v3/api-docs/**", "/configuration/**", "/swagger*/**", "/webjars/**", "/", "/console/**").permitAll() // permits all users to access Swagger V3 URLS
-            .antMatchers("/users/all", "/interventions").hasAnyRole("ADMIN")  // Restricts getting all users and intervention requests to ADMIN users.
+            .antMatchers(HttpMethod.POST, "/interventions").hasRole("CLIENT") // Only clients can add intervention requests
+            .antMatchers(HttpMethod.GET, "/interventions").hasRole("ADMIN") // Only admins can read the intervention list
+            .antMatchers("/users/all").hasAnyRole("ADMIN")  // Restricts getting all users and intervention requests to ADMIN users.
             .anyRequest().authenticated();// If you are authorized you will be able to access any routes that aren't specified to the ADMIN role.
         
        httpSecurity

--- a/Servers/cep-engagement-service/src/main/java/com/cepengagementservice/security/JwtUserDetails.java
+++ b/Servers/cep-engagement-service/src/main/java/com/cepengagementservice/security/JwtUserDetails.java
@@ -32,7 +32,7 @@ public class JwtUserDetails extends User implements UserDetails {
 		this.setEmail(user.getEmail());
 
 		List<SimpleGrantedAuthority> authorities = new ArrayList<SimpleGrantedAuthority>();
-		authorities.add(new SimpleGrantedAuthority("ROLE_" + getRole()));
+		authorities.add(new SimpleGrantedAuthority(getRole()));
 		this.authorities = authorities;
 	}
 
@@ -41,7 +41,7 @@ public class JwtUserDetails extends User implements UserDetails {
 		super();
 
 		List<SimpleGrantedAuthority> authorities = new ArrayList<SimpleGrantedAuthority>();
-		authorities.add(new SimpleGrantedAuthority("ROLE_" + getRole()));
+		authorities.add(new SimpleGrantedAuthority(getRole()));
 		this.authorities = authorities;
 	}
 


### PR DESCRIPTION
Changes the backend so it doesn't insert "ROLE_" before the user's role when setting authorizations in JwtUserDetails constructor (in response to the front-end now using ROLE_CLIENT and ROLE_ADMIN when creating accounts). Changes backend's AuthorizationConfig to properly filter access to /interventions by user role, allowing only clients to use POST /interventions and only admins to use GET /interventions.